### PR TITLE
Add Companion module metadata

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,0 +1,10 @@
+{
+  "name": "Christie DHD800",
+  "version": "0.0.1",
+  "manufacturer": "Christie",
+  "product": "DHD800",
+  "shortname": "christie-dhd800",
+  "type": "instance",
+  "main": "index.js",
+  "keywords": ["companion", "projector", "christie"]
+}

--- a/package.json
+++ b/package.json
@@ -16,5 +16,9 @@
   },
   "scripts": {
     "test": "jest"
+  },
+  "companion": {
+    "type": "instance",
+    "name": "Christie DHD800"
   }
 }


### PR DESCRIPTION
## Summary
- add module metadata for Bitfocus Companion

## Testing
- `npm test` *(fails: jest not found)*