### PR TITLE
Fix missing socket.io-client in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@companion-module/tools": "^2.3.0",
+    "socket.io-client": "file:externals/companion/node_modules/socket.io-client",
     "jest": "^29.0.0",
     "prettier": "^3.5.3"
   },

--- a/test-companion.js
+++ b/test-companion.js
@@ -158,7 +158,7 @@ function runDev(messages) {
 
 async function runHttpTests(messages) {
   const http = require("http");
-  const { io } = require("socket.io-client");
+  const { io } = require("./externals/companion/node_modules/socket.io-client");
 
   // basic connectivity check
   await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- use bundled `socket.io-client` when running Companion test harness
- document `socket.io-client` in dev dependencies so consumers know about it

## Testing
- `yarn test`
- `yarn test-companion`

------
https://chatgpt.com/codex/tasks/task_e_683f397a71788327be403d9e7b632204