### PR TITLE
Fix test harness config dir

### DIFF
--- a/test-companion.js
+++ b/test-companion.js
@@ -31,6 +31,7 @@ function startMockServer() {
   const messages = [];
   return new Promise((resolve) => {
     const server = net.createServer((socket) => {
+      socket.write("PASSWORD:\rHELLO\r");
       socket.on("data", (d) => {
         const msg = d.toString().trim();
         messages.push(msg);
@@ -72,7 +73,8 @@ async function copyModuleFiles(repoRoot) {
 
   for (const rel of files) {
     const src = path.join(repoRoot, rel);
-    const dest = path.join(destDir, path.basename(rel));
+    const dest = path.join(destDir, rel);
+    await fsPromises.mkdir(path.dirname(dest), { recursive: true });
     await fsPromises.copyFile(src, dest);
   }
 
@@ -116,10 +118,10 @@ function runDev(messages, keepRunning) {
     );
     console.log("\uD83D\uDCC1  Using temp config dir", configDir);
 
-    const proc = spawn("yarn", ["dev:inner"], {
+    const proc = spawn("yarn", ["dev:inner", "--config-dir", configDir], {
       stdio: ["ignore", "pipe", "pipe"],
       detached: true,
-      env: { ...process.env, COMPANION_CONFIG_BASEDIR: configDir },
+      env: { ...process.env },
     });
     let success = true;
     let serverReady = false;


### PR DESCRIPTION
## Summary
- ensure module-local-dev copy preserves companion directory structure
- emit PASSWORD and HELLO prompts in mock TCP server
- pass `--config-dir` to Companion during tests

## Testing
- `npx --yes prettier -w test-companion.js`
- `npx --yes jest` *(fails: 403 Forbidden)*
- `node test-companion.js` *(fails: ENOENT: yarn.lock)*

------
https://chatgpt.com/codex/tasks/task_e_683f7015db1083279f3da07c7f39690e