### PR TITLE
Add real projector testing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,11 @@ The following actions are available:
 - Menu On / Off
 
 Refer to the projector manual for further details.
+
+## Testing with Companion
+
+Run `yarn test-companion` to launch a local Companion instance and verify the
+module loads correctly. By default it uses a mock projector. Pass
+`--projector-ip <ip>` (or set the `PROJECTOR_IP` environment variable) to proxy
+commands to a real projector at the given IP address instead of the mock
+server.


### PR DESCRIPTION
## Summary
- allow specifying a real projector IP when running `yarn test-companion`
- proxy TCP traffic to the device so Companion still connects to localhost
- document the new flag in the README

## Testing
- `yarn test`
- `yarn test-companion` *(fails: Restart forced)*

------
https://chatgpt.com/codex/tasks/task_e_683fe0b7121083279cc6e869b3221a98