### PR TITLE
Add periodic status polling and feedbacks

### DIFF
--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -9,6 +9,10 @@ jest.mock("@companion-module/base", () => {
     setActionDefinitions(defs) {
       this.actionDefinitions = defs;
     }
+    setFeedbackDefinitions(defs) {
+      this.feedbackDefinitions = defs;
+    }
+    checkFeedbacksById() {}
     updateStatus() {}
     log() {}
   }
@@ -94,5 +98,20 @@ describe("ChristieDHD800Instance", () => {
     instance.config = {};
     instance.sendCommand("ABC");
     expect(logSpy).toHaveBeenCalledWith("error", "Host not configured");
+  });
+
+  test("sendCommand captures state", () => {
+    jest.useFakeTimers();
+    const instance = new InstanceClass({});
+    instance.config = { host: "127.0.0.1", port: 10000, password: "" };
+    const spy = jest.spyOn(instance, "checkFeedbacksById");
+    instance.sendCommand("C00");
+    let handlers = mockOn.mock.calls
+      .filter((c) => c[0] === "data")
+      .map((c) => c[1]);
+    const first = handlers[0];
+    expect(first).toBeDefined();
+    jest.runAllTimers();
+    jest.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary
- poll projector every 30s via telnet for power and input state
- capture projector state whenever sending a command
- expose feedbacks for power state and input source
- extend unit/integration tests for new behaviour

## Testing
- `yarn test`
- `yarn test-companion` *(fails: Codex couldn't run certain commands due to environnment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_683feb5edd20832792ca422d02720691