### PR TITLE
Fix open handle in tests

### DIFF
--- a/__tests__/main.js
+++ b/__tests__/main.js
@@ -71,6 +71,7 @@ describe("ChristieDHD800Instance additional tests", () => {
     instance.configUpdated({ host: "1.2.3.4" });
     expect(instance.config).toEqual({ host: "1.2.3.4" });
     expect(spy).toHaveBeenCalled();
+    instance.destroy();
   });
 
   test("destroy cleans up active socket", async () => {


### PR DESCRIPTION
## Summary
- clear polling timer after configUpdated test to avoid open handle

## Testing
- `yarn test --detectOpenHandles`
- `yarn test-companion` *(fails: Restart forced)*

------
https://chatgpt.com/codex/tasks/task_e_683ff0e2588483279b240510b6bb0300