### PR TITLE
Suppress module store warning lines

### DIFF
--- a/test-companion.js
+++ b/test-companion.js
@@ -208,6 +208,9 @@ async function runDev(messages, keepRunning) {
 
     const watch = (data) => {
       const text = data.toString();
+      if (/ModuleStoreService.*fetch failed/.test(text)) {
+        return;
+      }
       process.stdout.write(text);
 
       if (/new url:/i.test(text) && !serverReady) {


### PR DESCRIPTION
## Summary
- filter ModuleStoreService fetch failure messages from test output

## Testing
- `yarn format`
- `yarn test`
- `yarn test-companion` *(fails: Restart forced, cleaning up process)*

------
https://chatgpt.com/codex/tasks/task_e_6840fde7957c8327b71029cef68dd508