### PR TITLE
Wait for style in feedback test

### DIFF
--- a/test-companion.js
+++ b/test-companion.js
@@ -469,6 +469,9 @@ async function runHttpTests(messages, port, setPower) {
     { bgcolor: "#ff0000" },
   ]);
 
+  // Wait to ensure the style update has propagated before reading the preview
+  await new Promise((r) => setTimeout(r, 500));
+
   const fbAdded = await emitPromise("controls:entity:add", [
     controlId2,
     "feedbacks",


### PR DESCRIPTION
## Summary
- add a short delay after `controls:set-style-fields`

## Testing
- `yarn test`
- `yarn test-companion` *(fails: action definitions failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_684137de75a08327a65a1af9b50821b7