### PR TITLE
Fix feedback preview test color

### DIFF
--- a/test-companion.js
+++ b/test-companion.js
@@ -466,7 +466,7 @@ async function runHttpTests(messages, port, setPower) {
 
   await emitPromise("controls:set-style-fields", [
     controlId2,
-    { bgcolor: "#ff0000" },
+    { bgcolor: 0xff0000 },
   ]);
 
   // Wait to ensure the style update has propagated before reading the preview


### PR DESCRIPTION
## Summary
- fix `controls:set-style-fields` usage in integration test

## Testing
- `yarn test`
- `yarn test-companion` *(fails: action definitions failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_6841f8ed58a08327bb3fa1edc26a19df