### PR TITLE
Sequential state queries

### DIFF
--- a/__tests__/main.js
+++ b/__tests__/main.js
@@ -105,13 +105,13 @@ describe("ChristieDHD800Instance additional tests", () => {
     expect(mockSend).toHaveBeenCalledWith("\r");
     mockSend.mockClear();
     first("HELLO");
-    expect(mockSend).toHaveBeenCalledWith("CR0\r");
     expect(mockSend).toHaveBeenCalledWith("CR1\r");
     handlers = mockOn.mock.calls
       .filter((c) => c[0] === "data")
       .map((c) => c[1]);
     const second = handlers[handlers.length - 1];
     second("00");
-    second("1");
+    expect(mockSend).toHaveBeenCalledWith("CR2\r");
+    second("3");
   });
 });


### PR DESCRIPTION
## Summary
- poll projector power and input sequentially via CR1/CR2
- share state query code between `sendCommand` and `queryState`
- adjust unit test for new sequence

## Testing
- `yarn test`
- `yarn test-companion`


------
https://chatgpt.com/codex/tasks/task_e_68427cd42c008327895f9888bf671eae