### PR TITLE
Fix CR0 status request command

### DIFF
--- a/__tests__/main.js
+++ b/__tests__/main.js
@@ -105,13 +105,13 @@ describe("ChristieDHD800Instance additional tests", () => {
     expect(mockSend).toHaveBeenCalledWith("\r");
     mockSend.mockClear();
     first("HELLO");
-    expect(mockSend).toHaveBeenCalledWith("CR1\r");
+    expect(mockSend).toHaveBeenCalledWith("CR0\r");
     handlers = mockOn.mock.calls
       .filter((c) => c[0] === "data")
       .map((c) => c[1]);
     const second = handlers[handlers.length - 1];
     second("00");
-    expect(mockSend).toHaveBeenCalledWith("CR2\r");
+    expect(mockSend).toHaveBeenCalledWith("CR1\r");
     second("3");
   });
 });

--- a/main.js
+++ b/main.js
@@ -33,7 +33,7 @@ class ChristieDHD800Instance extends InstanceBase {
         }
         if (step === 0) {
           step = 1;
-          socket.send("CR2\r");
+          socket.send("CR1\r");
         } else {
           if (typeof socket.removeListener === "function") {
             socket.removeListener("data", parse);
@@ -48,7 +48,7 @@ class ChristieDHD800Instance extends InstanceBase {
       }
     };
     socket.on("data", (d) => parse(d.toString()));
-    socket.send("CR1\r");
+    socket.send("CR0\r");
   }
 
   init(config) {


### PR DESCRIPTION
## Summary
- update status command sequence to use CR0/CR1
- adjust unit tests for new sequence

## Testing
- `yarn format`
- `yarn test`
- `yarn test-companion` *(fails: HTTP tests failed Error: timeout)*

------
https://chatgpt.com/codex/tasks/task_e_684282a104908327ab60014bff6f8f92