### PR TITLE
Add variables for projector state

### DIFF
--- a/__tests__/main.js
+++ b/__tests__/main.js
@@ -1,6 +1,8 @@
 const mockSend = jest.fn();
 const mockOn = jest.fn();
 const mockDestroy = jest.fn();
+const mockSetVariableDefinitions = jest.fn();
+const mockSetVariableValues = jest.fn();
 let InstanceClass;
 
 jest.mock("@companion-module/base", () => {
@@ -11,6 +13,12 @@ jest.mock("@companion-module/base", () => {
     }
     setFeedbackDefinitions(defs) {
       this.feedbackDefinitions = defs;
+    }
+    setVariableDefinitions(defs) {
+      mockSetVariableDefinitions(defs);
+    }
+    setVariableValues(vals) {
+      mockSetVariableValues(vals);
     }
     checkFeedbacksById() {}
     updateStatus() {}
@@ -50,6 +58,8 @@ describe("ChristieDHD800Instance additional tests", () => {
     mockSend.mockClear();
     mockOn.mockClear();
     mockDestroy.mockClear();
+    mockSetVariableDefinitions.mockClear();
+    mockSetVariableValues.mockClear();
   });
 
   test("getConfigFields returns expected fields", () => {
@@ -113,5 +123,18 @@ describe("ChristieDHD800Instance additional tests", () => {
     second("00");
     expect(mockSend).toHaveBeenCalledWith("CR1\r");
     second("3");
+    expect(mockSetVariableValues).toHaveBeenCalledWith({
+      power_state: "Power ON",
+      input_source: 3,
+    });
+  });
+
+  test("init defines variables", () => {
+    const instance = new InstanceClass({});
+    instance.init({});
+    expect(mockSetVariableDefinitions).toHaveBeenCalledWith([
+      { variableId: "power_state", name: "Power State" },
+      { variableId: "input_source", name: "Input Source" },
+    ]);
   });
 });

--- a/main.js
+++ b/main.js
@@ -15,6 +15,13 @@ class ChristieDHD800Instance extends InstanceBase {
     this.pollTimer = undefined;
     this.powerState = undefined;
     this.inputState = undefined;
+    this.POWER_STATE_LABELS = {
+      "00": "Power ON",
+      80: "Standby",
+      40: "Countdown",
+      20: "Cooling",
+      10: "Failure",
+    };
   }
 
   requestState(socket, onFinish) {
@@ -42,6 +49,11 @@ class ChristieDHD800Instance extends InstanceBase {
           }
           this.powerState = responses[0];
           this.inputState = responses[1];
+          this.setVariableValues({
+            power_state:
+              this.POWER_STATE_LABELS[this.powerState] || this.powerState,
+            input_source: parseInt(this.inputState, 10),
+          });
           this.checkFeedbacksById("power_state", "input_source");
           if (onFinish) onFinish();
         }
@@ -57,6 +69,10 @@ class ChristieDHD800Instance extends InstanceBase {
     }
     this.updateStatus("ok");
     this.config = config;
+    this.setVariableDefinitions([
+      { variableId: "power_state", name: "Power State" },
+      { variableId: "input_source", name: "Input Source" },
+    ]);
     this.updateActions();
     this.updateFeedbacks();
 
@@ -87,6 +103,10 @@ class ChristieDHD800Instance extends InstanceBase {
       this.log("debug", "Configuration updated, reinitializing TCP");
     }
     this.config = config;
+    this.setVariableDefinitions([
+      { variableId: "power_state", name: "Power State" },
+      { variableId: "input_source", name: "Input Source" },
+    ]);
     this.initTCP();
     if (this.pollTimer) {
       clearInterval(this.pollTimer);


### PR DESCRIPTION
## Summary
- add variable definitions to track `power_state` and `input_source`
- update device state parsing to set the new variables
- test that variables are defined and updated

## Testing
- `yarn test`
- `yarn test-companion` *(fails: No output due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68428c77d8c88327b63f635459e4ee61