### PR TITLE
Add delay before querying state

### DIFF
--- a/main.js
+++ b/main.js
@@ -344,7 +344,9 @@ class ChristieDHD800Instance extends InstanceBase {
         }
         this.socket.send(cmd + "\r");
         commandSent = true;
-        this.requestState(this.socket);
+        setTimeout(() => {
+          this.requestState(this.socket);
+        }, 200);
         setTimeout(() => {
           if (NETWORK_DEBUG) {
             this.log("debug", "Command sent, destroying socket");


### PR DESCRIPTION
## Summary
- delay the state query by 200ms after sending a command

## Testing
- `yarn test`
- `yarn test-companion`


------
https://chatgpt.com/codex/tasks/task_e_684309573ad48327b3889ec1d64d16f7