### PR TITLE
Fix Jest open handle by destroying pollTimer in tests

### DIFF
--- a/__tests__/main.js
+++ b/__tests__/main.js
@@ -136,6 +136,7 @@ describe("ChristieDHD800Instance additional tests", () => {
       { variableId: "power_state", name: "Power State" },
       { variableId: "input_source", name: "Input Source" },
     ]);
+    instance.destroy();
   });
 
   test("requestState triggers feedback check", () => {


### PR DESCRIPTION
## Summary
- call `instance.destroy()` in unit test to clear poll timer

## Testing
- `yarn test`
- `yarn test-companion`


------
https://chatgpt.com/codex/tasks/task_e_684366c38e088327b76bba0ac73aae8d