### PR TITLE
Fix preview color update

### DIFF
--- a/__tests__/main.js
+++ b/__tests__/main.js
@@ -44,6 +44,7 @@ jest.mock("@companion-module/base", () => {
   return {
     InstanceBase: MockInstanceBase,
     Regex: { HOSTNAME: /.+/, PORT: /^\d+$/ },
+    combineRgb: (r, g, b) => (r << 16) | (g << 8) | b,
     TCPHelper: MockTCPHelper,
     runEntrypoint: jest.fn((cls) => {
       InstanceClass = cls;

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -44,6 +44,7 @@ jest.mock("@companion-module/base", () => {
   return {
     InstanceBase: MockInstanceBase,
     Regex: { HOSTNAME: /.+/, PORT: /^\d+$/ },
+    combineRgb: (r, g, b) => (r << 16) | (g << 8) | b,
     TCPHelper: MockTCPHelper,
     runEntrypoint: jest.fn((cls) => {
       InstanceClass = cls;

--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ const {
   Regex,
   runEntrypoint,
   TCPHelper,
+  combineRgb,
 } = require("@companion-module/base");
 
 // Toggle to enable verbose network debugging logs
@@ -223,7 +224,7 @@ class ChristieDHD800Instance extends InstanceBase {
             ],
           },
         ],
-        defaultStyle: { bgcolor: "#00ff00" },
+        defaultStyle: { bgcolor: combineRgb(0, 255, 0) },
         callback: (fb) => this.powerState === fb.options.state,
       },
       input_source: {
@@ -243,7 +244,7 @@ class ChristieDHD800Instance extends InstanceBase {
             ],
           },
         ],
-        defaultStyle: { bgcolor: "#0000ff" },
+        defaultStyle: { bgcolor: combineRgb(0, 0, 255) },
         callback: (fb) => this.inputState === fb.options.slot,
       },
     };


### PR DESCRIPTION
## Summary
- send numeric color codes in feedback definitions
- adjust unit test mocks for combineRgb

## Testing
- `yarn test`
- `yarn test-companion` *(fails: preview did not change after state update)*

------
https://chatgpt.com/codex/tasks/task_e_684396cdd84c83279ecbf9c9c5ffb82e