### PR TITLE
Adjust test color sampling

### DIFF
--- a/test-companion.js
+++ b/test-companion.js
@@ -389,7 +389,9 @@ async function runHttpTests(messages, port, setPower) {
     const data = zlib.inflateSync(Buffer.concat(idat));
     const bytesPerPixel = 4;
     const stride = width * bytesPerPixel + 1;
-    const idx = 1 * stride + 1 * bytesPerPixel; // pixel (1,1) avoid border
+    const x = Math.floor(width / 2);
+    const y = Math.floor(height / 2);
+    const idx = y * stride + 1 + x * bytesPerPixel; // center pixel
     const r = data[idx];
     const g = data[idx + 1];
     const b = data[idx + 2];


### PR DESCRIPTION
## Summary
- pull preview colors from the middle of the button in `test-companion.js`

## Testing
- `yarn test`
- `yarn test-companion` *(fails: Cleaning up Companion process)*

------
https://chatgpt.com/codex/tasks/task_e_6843cc671a1c8327950abf4d7c39f47c