### PR TITLE
Update color checking to use websocket API

### DIFF
--- a/test-companion.js
+++ b/test-companion.js
@@ -403,6 +403,15 @@ async function runHttpTests(messages, port, setPower) {
     );
   }
 
+  async function getButtonColor(controlId) {
+    const res = await emitPromise("controls:subscribe", [controlId]);
+    await emitPromise("controls:unsubscribe", [controlId]);
+    const val = res?.config?.style?.bgcolor;
+    return typeof val === "number"
+      ? `#${val.toString(16).padStart(6, "0")}`
+      : null;
+  }
+
   const socket = io(`http://127.0.0.1:${port}`, { transports: ["websocket"] });
   await new Promise((resolve) => socket.on("connect", resolve));
 
@@ -499,7 +508,7 @@ async function runHttpTests(messages, port, setPower) {
     { bgcolor: 0xff0000 },
   ]);
 
-  // Wait to ensure the style update has propagated before reading the preview
+  // Wait to ensure the style update has propagated before querying
   await new Promise((r) => setTimeout(r, 500));
 
   const fbAdded = await emitPromise("controls:entity:add", [
@@ -519,26 +528,7 @@ async function runHttpTests(messages, port, setPower) {
     "00",
   ]);
 
-  let previewImage = null;
-  socket.on("preview:location:render", (loc, img) => {
-    if (
-      loc.pageNumber === location.pageNumber &&
-      loc.row === location.row &&
-      loc.column === location.column
-    ) {
-      previewImage = img;
-    }
-  });
-  const subId = "testsub";
-  const initPrev = await emitPromise("preview:location:subscribe", [
-    location,
-    subId,
-  ]);
-  previewImage = initPrev.image;
-
-  if (!previewImage) throw new Error("initial preview missing");
-  const initial = previewImage;
-  const initialColor = extractColor(initial);
+  const initialColor = await getButtonColor(controlId2);
   if (initialColor !== "#ff0000" && initialColor !== "#000000") {
     throw new Error(`unexpected initial color ${initialColor}`);
   }
@@ -546,14 +536,10 @@ async function runHttpTests(messages, port, setPower) {
   setPower("00");
   await httpPost(`/api/location/1/1/1/press`);
   await new Promise((r) => setTimeout(r, 75000));
-  if (previewImage === initial) {
-    throw new Error("preview did not change after state update");
-  }
-  const newColor = extractColor(previewImage);
+  const newColor = await getButtonColor(controlId2);
   if (newColor !== "#00ff00") {
     throw new Error(`unexpected updated color ${newColor}`);
   }
-  await emitPromise("preview:location:unsubscribe", [location, subId]);
 
   socket.close();
 }


### PR DESCRIPTION
## Summary
- add utility to read button color with `controls:subscribe`
- use websocket color query in integration test

## Testing
- `yarn test`
- `yarn test-companion` *(fails due to missing success output)*

------
https://chatgpt.com/codex/tasks/task_e_6843d1a41b688327bc91e0a1a690bab3