### PR TITLE
Refactor extractColor to util

### DIFF
--- a/integration/test-companion.js
+++ b/integration/test-companion.js
@@ -22,7 +22,7 @@ const fsPromises = require("fs/promises");
 const path = require("path");
 const os = require("os");
 const net = require("net");
-const zlib = require("zlib");
+const { extractColor } = require("./util");
 
 const savePreview =
   process.argv.includes("--save-preview") || process.env.SAVE_PREVIEW === "1";
@@ -363,47 +363,6 @@ async function runHttpTests(messages, port, setPower) {
       req.on("error", reject);
       req.end();
     });
-  }
-
-  function extractColor(image) {
-    if (!image) return null;
-    const b64 = image.replace(/^data:image\/png;base64,/, "");
-    const buf = Buffer.from(b64, "base64");
-    const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
-    if (!buf.subarray(0, 8).equals(sig)) return null;
-    let pos = 8;
-    let width = 0;
-    let height = 0;
-    const idat = [];
-    while (pos < buf.length) {
-      const len = buf.readUInt32BE(pos);
-      const type = buf.subarray(pos + 4, pos + 8).toString("ascii");
-      pos += 8;
-      if (type === "IHDR") {
-        width = buf.readUInt32BE(pos);
-        height = buf.readUInt32BE(pos + 4);
-      } else if (type === "IDAT") {
-        idat.push(buf.subarray(pos, pos + len));
-      }
-      pos += len + 4; // skip chunk data + crc
-      if (type === "IEND") break;
-    }
-    if (width <= 0 || height <= 0 || idat.length === 0) return null;
-    const data = zlib.inflateSync(Buffer.concat(idat));
-    const bytesPerPixel = 4;
-    const stride = width * bytesPerPixel + 1;
-    const x = Math.floor(width / 2);
-    const y = Math.floor(height / 2);
-    const idx = y * stride + 1 + x * bytesPerPixel; // center pixel
-    const r = data[idx];
-    const g = data[idx + 1];
-    const b = data[idx + 2];
-    return (
-      "#" +
-      r.toString(16).padStart(2, "0") +
-      g.toString(16).padStart(2, "0") +
-      b.toString(16).padStart(2, "0")
-    );
   }
 
   const socket = io(`http://127.0.0.1:${port}`, { transports: ["websocket"] });

--- a/integration/util.js
+++ b/integration/util.js
@@ -1,0 +1,44 @@
+const zlib = require("zlib");
+
+function extractColor(image) {
+  if (!image) return null;
+  const b64 = image.replace(/^data:image\/png;base64,/, "");
+  const buf = Buffer.from(b64, "base64");
+  const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  if (!buf.subarray(0, 8).equals(sig)) return null;
+  let pos = 8;
+  let width = 0;
+  let height = 0;
+  const idat = [];
+  while (pos < buf.length) {
+    const len = buf.readUInt32BE(pos);
+    const type = buf.subarray(pos + 4, pos + 8).toString("ascii");
+    pos += 8;
+    if (type === "IHDR") {
+      width = buf.readUInt32BE(pos);
+      height = buf.readUInt32BE(pos + 4);
+    } else if (type === "IDAT") {
+      idat.push(buf.subarray(pos, pos + len));
+    }
+    pos += len + 4; // skip chunk data + crc
+    if (type === "IEND") break;
+  }
+  if (width <= 0 || height <= 0 || idat.length === 0) return null;
+  const data = zlib.inflateSync(Buffer.concat(idat));
+  const bytesPerPixel = 4;
+  const stride = width * bytesPerPixel + 1;
+  const x = Math.floor(width / 2);
+  const y = Math.floor(height / 2);
+  const idx = y * stride + 1 + x * bytesPerPixel; // center pixel
+  const r = data[idx];
+  const g = data[idx + 1];
+  const b = data[idx + 2];
+  return (
+    "#" +
+    r.toString(16).padStart(2, "0") +
+    g.toString(16).padStart(2, "0") +
+    b.toString(16).padStart(2, "0")
+  );
+}
+
+module.exports = { extractColor };


### PR DESCRIPTION
## Summary
- move `extractColor` function into integration util
- use new util in `test-companion.js`

## Testing
- `yarn format`
- `yarn test`
- `yarn test-companion`


------
https://chatgpt.com/codex/tasks/task_e_68447dd91d2c83279cc13a2a06e3c740